### PR TITLE
[Body Type]Take non-JSON body as plain text

### DIFF
--- a/common/common-rest/src/main/java/io/servicecomb/common/rest/codec/param/BodyProcessorCreator.java
+++ b/common/common-rest/src/main/java/io/servicecomb/common/rest/codec/param/BodyProcessorCreator.java
@@ -63,7 +63,7 @@ public class BodyProcessorCreator implements ParamValueProcessorCreator {
       }
 
       String contentType = request.getContentType();
-      if (contentType != null && contentType.startsWith(MediaType.TEXT_PLAIN)) {
+      if (contentType != null && !contentType.startsWith(MediaType.APPLICATION_JSON)) {
         // TODO: we should consider body encoding
         return IOUtils.toString(inputStream, "UTF-8");
       }


### PR DESCRIPTION
Media type which is not application/json, like text/plain and some self defined media types, can not be processed as JSON.