### PR TITLE
JAV-403 ignored non-rest style interfaces using @RestSchema

### DIFF
--- a/swagger/swagger-generator/generator-core/src/main/java/io/servicecomb/swagger/generator/core/SwaggerGenerator.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/io/servicecomb/swagger/generator/core/SwaggerGenerator.java
@@ -210,7 +210,7 @@ public class SwaggerGenerator {
     }
 
     ApiOperation apiOperation = method.getAnnotation(ApiOperation.class);
-    if (apiOperation != null) {
+    if (apiOperation != null && apiOperation.hidden()) {
       return apiOperation.hidden();
     }
 

--- a/swagger/swagger-generator/generator-core/src/test/java/io/servicecomb/swagger/generator/core/TestApiOperation.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/io/servicecomb/swagger/generator/core/TestApiOperation.java
@@ -16,6 +16,10 @@
 
 package io.servicecomb.swagger.generator.core;
 
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
 import java.util.Map;
 
@@ -69,6 +73,9 @@ public class TestApiOperation {
 
     @ApiOperation(value = "aaa", response = Integer.class, responseContainer = "Set")
     int testSet();
+
+    @ApiOperation(value = "aaa", hidden = true)
+    int testHidden();
   }
 
   interface UnknownResponseContainer {
@@ -88,6 +95,7 @@ public class TestApiOperation {
     testMap(swagger.getPath("/testMap"));
     testList(swagger.getPath("/testList"));
     testSet(swagger.getPath("/testSet"));
+    assertThat(swagger.getPath("/testHidden"), is(nullValue()));
   }
 
   @Test

--- a/swagger/swagger-generator/generator-jaxrs/src/test/java/io/servicecomb/swagger/generator/jaxrs/Echo.java
+++ b/swagger/swagger-generator/generator-jaxrs/src/test/java/io/servicecomb/swagger/generator/jaxrs/Echo.java
@@ -87,4 +87,9 @@ public class Echo {
   public String queryComplex(@QueryParam(value = "querys") List<User> querys) {
     return String.format("%s", querys);
   }
+
+  @ApiOperation(value = "")
+  public void ignoredNonRestful() {
+
+  }
 }

--- a/swagger/swagger-generator/generator-jaxrs/src/test/java/io/servicecomb/swagger/generator/jaxrs/TestJaxrs.java
+++ b/swagger/swagger-generator/generator-jaxrs/src/test/java/io/servicecomb/swagger/generator/jaxrs/TestJaxrs.java
@@ -85,6 +85,11 @@ public class TestJaxrs {
   }
 
   @Test
+  public void testNonRestful() throws Exception {
+    UnitTestSwaggerUtils.testSwagger("schemas/emptyContract.yaml", context, Echo.class, "ignoredNonRestful");
+  }
+
+  @Test
   public void testClassMethodNoPath() throws Exception {
     UnitTestSwaggerUtils.testException(
         "generate operation swagger failed, io.servicecomb.swagger.generator.jaxrs.ClassMethodNoPath:p1",

--- a/swagger/swagger-generator/generator-jaxrs/src/test/resources/schemas/emptyContract.yaml
+++ b/swagger/swagger-generator/generator-jaxrs/src/test/resources/schemas/emptyContract.yaml
@@ -1,0 +1,11 @@
+---
+swagger: "2.0"
+info:
+  version: "1.0.0"
+  title: "swagger definition for io.servicecomb.swagger.generator.jaxrs.Echo"
+  x-java-interface: "gen.cse.ms.ut.EchoIntf"
+basePath: "/Echo"
+consumes:
+- "application/json"
+produces:
+- "application/json"

--- a/swagger/swagger-generator/generator-springmvc/src/test/java/io/servicecomb/swagger/generator/springmvc/MethodEmptyPath.java
+++ b/swagger/swagger-generator/generator-springmvc/src/test/java/io/servicecomb/swagger/generator/springmvc/MethodEmptyPath.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import io.swagger.annotations.ApiOperation;
+
 @RequestMapping(path = "MethodEmptyPath")
 public class MethodEmptyPath {
 
@@ -48,6 +50,13 @@ public class MethodEmptyPath {
 
   @PatchMapping
   public void usingPatchMapping() {
+
+  }
+
+  // this will be ignored in the generation of service contract
+  // as ApiOperation is not a restful annotation
+  @ApiOperation(value = "")
+  public void ignoredNonRestful() {
 
   }
 }


### PR DESCRIPTION
This issue turns out to be a bug. When the apiOperation is neither null nor hidden, methods annotates with ApiOperation will publish as a service.