### PR TITLE
JAV-409 Fix JavaDoc Error for Spring-Cloud-Zuul-Zipkin

### DIFF
--- a/spring-boot-starter/spring-cloud-zuul-zipkin/src/main/java/io/servicecomb/spring/cloud/zuul/tracing/SpringTracingConfiguration.java
+++ b/spring-boot-starter/spring-cloud-zuul-zipkin/src/main/java/io/servicecomb/spring/cloud/zuul/tracing/SpringTracingConfiguration.java
@@ -42,7 +42,7 @@ import brave.servlet.TracingFilter;
 
 @Configuration
 @ConditionalOnProperty(value = CONFIG_TRACING_ENABLED_KEY, havingValue = "true", matchIfMissing = true)
-class SpringTracingConfiguration {
+public class SpringTracingConfiguration {
 
   @Bean
   FilterRegistrationBean traceWebFilter(HttpTracing httpTracing) {


### PR DESCRIPTION
There was no public class in this module because of which JavaDoc gives error in Deployment Process.