### PR TITLE
JAV-474 fix servlet timeout concurrent problems

### DIFF
--- a/common/common-rest/src/main/java/io/servicecomb/common/rest/RestConst.java
+++ b/common/common-rest/src/main/java/io/servicecomb/common/rest/RestConst.java
@@ -43,5 +43,7 @@ public final class RestConst {
 
   public static final String REST_REQUEST = "servicecomb-rest-request";
 
+  public static final String REST_STATE_EXECUTING = "servicecomb-rest-state-executing";
+
   public static final String CONSUMER_HEADER = "servicecomb-rest-consumer-header";
 }

--- a/common/common-rest/src/main/java/io/servicecomb/common/rest/RestProducerInvocation.java
+++ b/common/common-rest/src/main/java/io/servicecomb/common/rest/RestProducerInvocation.java
@@ -50,6 +50,7 @@ public class RestProducerInvocation extends AbstractRestInvocation {
     this.requestEx = requestEx;
     this.responseEx = responseEx;
     this.httpServerFilters = httpServerFilters;
+    requestEx.setAttribute(RestConst.REST_REQUEST, requestEx);
 
     try {
       this.restOperationMeta = findRestOperation();
@@ -64,11 +65,23 @@ public class RestProducerInvocation extends AbstractRestInvocation {
   protected void scheduleInvocation() {
     OperationMeta operationMeta = restOperationMeta.getOperationMeta();
     operationMeta.getExecutor().execute(() -> {
-      try {
-        runOnExecutor();
-      } catch (Exception e) {
-        LOGGER.error("rest server onRequest error", e);
-        sendFailResponse(e);
+      synchronized (this.requestEx) {
+        try {
+          if (requestEx.getAttribute(RestConst.REST_REQUEST) != requestEx) {
+            // already timeout
+            // in this time, request maybe recycled and reused by web container, do not use requestEx
+            LOGGER.error("Rest request already timeout, abandon execute, method {}, operation {}.",
+                operationMeta.getHttpMethod(),
+                operationMeta.getMicroserviceQualifiedName());
+            return;
+          }
+
+          requestEx.setAttribute(RestConst.REST_STATE_EXECUTING, true);
+          runOnExecutor();
+        } catch (Throwable e) {
+          LOGGER.error("rest server onRequest error", e);
+          sendFailResponse(e);
+        }
       }
     });
   }

--- a/common/common-rest/src/test/java/io/servicecomb/common/rest/TestRestProducerInvocation.java
+++ b/common/common-rest/src/test/java/io/servicecomb/common/rest/TestRestProducerInvocation.java
@@ -47,6 +47,7 @@ import io.servicecomb.core.definition.MicroserviceMeta;
 import io.servicecomb.core.definition.MicroserviceMetaManager;
 import io.servicecomb.core.definition.OperationMeta;
 import io.servicecomb.core.definition.SchemaMeta;
+import io.servicecomb.core.executor.ReactiveExecutor;
 import io.servicecomb.foundation.vertx.http.AbstractHttpServletRequest;
 import io.servicecomb.foundation.vertx.http.HttpServletRequestEx;
 import io.servicecomb.foundation.vertx.http.HttpServletResponseEx;
@@ -147,17 +148,22 @@ public class TestRestProducerInvocation {
       }
     }.getMockInstance();
 
+    requestEx = new AbstractHttpServletRequest() {
+    };
     restProducerInvocation.invoke(transport, requestEx, responseEx, httpServerFilters);
 
     Assert.assertTrue(scheduleInvocation);
+    Assert.assertSame(requestEx, requestEx.getAttribute(RestConst.REST_REQUEST));
   }
 
   @Test
-  public void scheduleInvocation(@Mocked OperationMeta operationMeta) {
+  public void scheduleInvocationNormal(@Mocked OperationMeta operationMeta) {
     Executor executor = cmd -> {
       cmd.run();
     };
-
+    requestEx = new AbstractHttpServletRequest() {
+    };
+    requestEx.setAttribute(RestConst.REST_REQUEST, requestEx);
     new Expectations() {
       {
         restOperationMeta.getOperationMeta();
@@ -178,6 +184,70 @@ public class TestRestProducerInvocation {
     restProducerInvocation.scheduleInvocation();
 
     Assert.assertTrue(runOnExecutor);
+    Assert.assertTrue((boolean) requestEx.getAttribute(RestConst.REST_STATE_EXECUTING));
+  }
+
+  @Test
+  public void scheduleInvocationTimeout(@Mocked OperationMeta operationMeta) {
+    Executor executor = cmd -> {
+      cmd.run();
+    };
+
+    new Expectations() {
+      {
+        restOperationMeta.getOperationMeta();
+        result = operationMeta;
+        operationMeta.getExecutor();
+        result = executor;
+      }
+    };
+
+    requestEx = new AbstractHttpServletRequest() {
+    };
+
+    restProducerInvocation = new MockUp<RestProducerInvocation>() {
+      @Mock
+      void runOnExecutor() {
+        runOnExecutor = true;
+      }
+    }.getMockInstance();
+    initRestProducerInvocation();
+
+    restProducerInvocation.scheduleInvocation();
+
+    Assert.assertFalse(runOnExecutor);
+    Assert.assertNull(requestEx.getAttribute(RestConst.REST_STATE_EXECUTING));
+  }
+
+  @Test
+  public void scheduleInvocationException(@Mocked OperationMeta operationMeta) {
+    Executor executor = new ReactiveExecutor();
+    Throwable e = new Exception("Param error");
+    new Expectations(RestCodec.class) {
+      {
+        restOperationMeta.getOperationMeta();
+        result = operationMeta;
+        operationMeta.getExecutor();
+        result = executor;
+        requestEx.getAttribute(RestConst.REST_REQUEST);
+        result = requestEx;
+        RestCodec.restToArgs(requestEx, restOperationMeta);
+        result = e;
+      }
+    };
+
+    Holder<Throwable> result = new Holder<>();
+    restProducerInvocation = new MockUp<RestProducerInvocation>() {
+      @Mock
+      void sendFailResponse(Throwable throwable) {
+        result.value = throwable;
+      }
+    }.getMockInstance();
+
+    initRestProducerInvocation();
+    restProducerInvocation.scheduleInvocation();
+
+    Assert.assertSame(e, result.value);
   }
 
   @Test
@@ -201,24 +271,6 @@ public class TestRestProducerInvocation {
 
     Assert.assertTrue(invokeNoParam);
     Assert.assertSame(args, restProducerInvocation.invocation.getSwaggerArguments());
-  }
-
-  @Test
-  public void runOnExecutorException() {
-    expectedException.expect(Exception.class);
-    expectedException.expectMessage("Param error");
-    new Expectations(RestCodec.class) {
-      {
-        RestCodec.restToArgs(requestEx, restOperationMeta);
-        result = new Exception("Param error");
-      }
-    };
-
-    restProducerInvocation = new MockUp<RestProducerInvocation>() {
-    }.getMockInstance();
-
-    initRestProducerInvocation();
-    restProducerInvocation.runOnExecutor();
   }
 
   @Test

--- a/demo/demo-perf-client/src/main/resources/microservice.yaml
+++ b/demo/demo-perf-client/src/main/resources/microservice.yaml
@@ -1,4 +1,5 @@
-﻿APPLICATION_ID: pojotest
+﻿cse-config-order: 100
+APPLICATION_ID: pojotest
 service_description:
   name: perfClient
   version: 0.0.1

--- a/transports/transport-rest/transport-rest-servlet/src/main/java/io/servicecomb/transport/rest/servlet/RestAsyncListener.java
+++ b/transports/transport-rest/transport-rest-servlet/src/main/java/io/servicecomb/transport/rest/servlet/RestAsyncListener.java
@@ -21,20 +21,69 @@ import java.io.PrintWriter;
 
 import javax.servlet.AsyncEvent;
 import javax.servlet.AsyncListener;
+import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.servicecomb.common.rest.RestConst;
+import io.servicecomb.foundation.common.utils.JsonUtils;
+import io.servicecomb.foundation.vertx.http.HttpServletRequestEx;
+import io.servicecomb.swagger.invocation.exception.CommonExceptionData;
+import io.servicecomb.swagger.invocation.exception.ExceptionFactory;
 
 public class RestAsyncListener implements AsyncListener {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RestAsyncListener.class);
+
+  private static String TIMEOUT_MESSAGE;
+  static {
+    try {
+      TIMEOUT_MESSAGE = JsonUtils.writeValueAsString(new CommonExceptionData("TimeOut in Processing"));
+    } catch (JsonProcessingException e) {
+      LOGGER.error("Failed to init timeout message.", e);
+    }
+  }
+
   @Override
   public void onComplete(AsyncEvent event) throws IOException {
-    // 未使用
   }
 
   @Override
   public void onTimeout(AsyncEvent event) throws IOException {
-    // TODO:超时的处理，要重新考虑
-    ServletResponse response = event.getAsyncContext().getResponse();
-    PrintWriter out = response.getWriter();
-    out.write("TimeOut Error in Processing");
+    // in this time, maybe:
+    // 1.invocation in executor's queue
+    // 2.already executing in executor
+    // 3.already send response
+    // to avoid concurrent, must lock request
+    ServletRequest request = event.getSuppliedRequest();
+    HttpServletRequestEx requestEx = (HttpServletRequestEx) request.getAttribute(RestConst.REST_REQUEST);
+    if (requestEx.getAttribute(RestConst.REST_STATE_EXECUTING) != null) {
+      // executing or already send response
+      return;
+    }
+
+    synchronized (requestEx) {
+      ServletResponse response = event.getAsyncContext().getResponse();
+      if (!response.isCommitted()) {
+        LOGGER.error("Rest request timeout, method {}, path {}.", requestEx.getMethod(), requestEx.getRequestURI());
+        // invocation in executor's queue
+        response.setContentType(MediaType.APPLICATION_JSON);
+        
+        // we don't know if developers declared one statusCode in contract
+        // so we use cse inner statusCode here
+        ((HttpServletResponse) response).setStatus(ExceptionFactory.PRODUCER_INNER_STATUS_CODE);
+        PrintWriter out = response.getWriter();
+        out.write(TIMEOUT_MESSAGE);
+        response.flushBuffer();
+      }
+
+      request.removeAttribute(RestConst.REST_REQUEST);
+    }
   }
 
   @Override

--- a/transports/transport-rest/transport-rest-servlet/src/test/java/io/servicecomb/transport/rest/servlet/TestRestAsyncListener.java
+++ b/transports/transport-rest/transport-rest-servlet/src/test/java/io/servicecomb/transport/rest/servlet/TestRestAsyncListener.java
@@ -18,40 +18,124 @@ package io.servicecomb.transport.rest.servlet;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
 
 import javax.servlet.AsyncContext;
 import javax.servlet.AsyncEvent;
-import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
+
+import io.servicecomb.common.rest.RestConst;
+import io.servicecomb.foundation.vertx.http.AbstractHttpServletRequest;
+import io.servicecomb.foundation.vertx.http.HttpServletRequestEx;
+import io.servicecomb.foundation.vertx.http.StandardHttpServletRequestEx;
+import io.servicecomb.swagger.invocation.exception.ExceptionFactory;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
 
 public class TestRestAsyncListener {
+  HttpServletRequest request = new AbstractHttpServletRequest() {
+    public String getMethod() {
+      return "GET";
+    };
+
+    public String getRequestURI() {
+      return "path";
+    };
+  };
+
+  HttpServletRequestEx requestEx = new StandardHttpServletRequestEx(request);
+
+  boolean committed;
+
+  boolean flushed;
+
+  int statusCode;
+
+  String contentType;
+
+  Writer writer = new StringWriter();
+
+  PrintWriter printWriter = new PrintWriter(writer);
+
+  @Mocked
+  HttpServletResponse response;
+
+  @Mocked
+  AsyncContext context;
+
+  AsyncEvent event;
+
+  RestAsyncListener listener = new RestAsyncListener();
+
+
+  @Before
+  public void setup() {
+    event = new AsyncEvent(context, requestEx, response);
+    requestEx.setAttribute(RestConst.REST_REQUEST, requestEx);
+
+    new MockUp<HttpServletResponse>(response) {
+      @Mock
+      void setContentType(String type) {
+        contentType = type;
+      }
+
+      @Mock
+      void setStatus(int sc) {
+        statusCode = sc;
+      }
+
+      @Mock
+      boolean isCommitted() {
+        return committed;
+      }
+
+      @Mock
+      PrintWriter getWriter() throws IOException {
+        return printWriter;
+      }
+
+      @Mock
+      void flushBuffer() throws IOException {
+        flushed = true;
+      }
+    };
+  }
 
   @Test
-  public void testOnTimeout() throws IOException {
+  public void onTimeoutExecuting() throws IOException {
+    request.setAttribute(RestConst.REST_STATE_EXECUTING, true);
 
-    boolean status = true;
-    try {
-      RestAsyncListener restasynclistener = new RestAsyncListener();
-      AsyncEvent event = Mockito.mock(AsyncEvent.class);
-      AsyncContext asynccontext = Mockito.mock(AsyncContext.class);
-      Mockito.when(event.getAsyncContext()).thenReturn(asynccontext);
-      ServletResponse response = Mockito.mock(ServletResponse.class);
-      Mockito.when(asynccontext.getResponse()).thenReturn(response);
+    listener.onTimeout(event);
 
-      PrintWriter out = Mockito.mock(PrintWriter.class);
-      Mockito.when(response.getWriter()).thenReturn(out);
-      restasynclistener.onTimeout(event);
-      restasynclistener.onComplete(event);
-      restasynclistener.onError(event);
-      restasynclistener.onStartAsync(event);
-      Assert.assertNotNull(restasynclistener);
-    } catch (Exception e) {
-      status = false;
-      Assert.assertNotNull(e);
-    }
-    Assert.assertTrue(status);
+    Assert.assertSame(requestEx, request.getAttribute(RestConst.REST_REQUEST));
+  }
+
+  @Test
+  public void onTimeoutCommitted() throws IOException {
+    committed = true;
+    listener.onTimeout(event);
+
+    Assert.assertNull(request.getAttribute(RestConst.REST_REQUEST));
+    Assert.assertFalse(flushed);
+  }
+
+  @Test
+  public void onTimeoutNotCommitted() throws IOException {
+    committed = false;
+    listener.onTimeout(event);
+
+    Assert.assertNull(request.getAttribute(RestConst.REST_REQUEST));
+    Assert.assertEquals(MediaType.APPLICATION_JSON, contentType);
+    Assert.assertEquals(ExceptionFactory.PRODUCER_INNER_STATUS_CODE, statusCode);
+    Assert.assertTrue(flushed);
+    Assert.assertEquals("{\"message\":\"TimeOut in Processing\"}", writer.toString());
   }
 }


### PR DESCRIPTION
1.receive a servlet request, start async and dispatch to executor
2.if business is slow, then web container will call async timeout and recycled resources
　　but in this time, resources maybe in executor's queue or executing
　　that will cause many strange problems, like request not support async or some NullException