### PR TITLE
used finally to execute common codes

### DIFF
--- a/core/src/main/java/io/servicecomb/core/handler/ShutdownHookHandler.java
+++ b/core/src/main/java/io/servicecomb/core/handler/ShutdownHookHandler.java
@@ -68,10 +68,8 @@ public final class ShutdownHookHandler implements Handler, Runnable {
       invocation.next(resp -> {
         try {
           asyncResp.handle(resp);
+        } finally {
           responseCounter.incrementAndGet();
-        } catch (Throwable e) {
-          responseCounter.incrementAndGet();
-          throw e;
         }
       });
     } catch (Throwable e) {


### PR DESCRIPTION
`responseCounter.incrementAndGet()` can be executed in finally block instead of being called twice in the try block.