### PR TITLE
[JAV-560] fix null header process logic on consumer side

### DIFF
--- a/common/common-rest/src/main/java/io/servicecomb/common/rest/codec/param/HeaderProcessorCreator.java
+++ b/common/common-rest/src/main/java/io/servicecomb/common/rest/codec/param/HeaderProcessorCreator.java
@@ -56,6 +56,10 @@ public class HeaderProcessorCreator implements ParamValueProcessorCreator {
 
     @Override
     public void setValue(RestClientRequest clientRequest, Object arg) throws Exception {
+      if (null == arg) {
+        // null header should not be set to clientRequest to avoid NullPointerException in Netty.
+        return;
+      }
       clientRequest.putHeader(paramPath, RestObjectMapper.INSTANCE.convertToString(arg));
     }
 

--- a/common/common-rest/src/test/java/io/servicecomb/common/rest/codec/param/TestHeaderProcessor.java
+++ b/common/common-rest/src/test/java/io/servicecomb/common/rest/codec/param/TestHeaderProcessor.java
@@ -162,6 +162,14 @@ public class TestHeaderProcessor {
   }
 
   @Test
+  public void testSetValueNull() throws Exception {
+    createClientRequest();
+    HeaderProcessor processor = createProcessor("h1", String.class);
+    processor.setValue(clientRequest, null);
+    Assert.assertEquals(0, headers.size());
+  }
+
+  @Test
   public void testSetValueDate() throws Exception {
     Date date = new Date();
     String strDate = ISO8601Utils.format(date);

--- a/providers/provider-springmvc/src/main/java/io/servicecomb/provider/springmvc/reference/RestTemplateCopyHeaderFilter.java
+++ b/providers/provider-springmvc/src/main/java/io/servicecomb/provider/springmvc/reference/RestTemplateCopyHeaderFilter.java
@@ -40,6 +40,10 @@ public class RestTemplateCopyHeaderFilter implements HttpClientFilter {
 
     httpHeaders.forEach((key, values) -> {
       for (String value : values) {
+        // null args should not be set to requestEx to avoid NullPointerException in Netty.
+        if (null == value) {
+          continue;
+        }
         requestEx.addHeader(key, value);
       }
     });

--- a/providers/provider-springmvc/src/test/java/io/servicecomb/provider/springmvc/reference/TestRestTemplateCopyHeaderFilter.java
+++ b/providers/provider-springmvc/src/test/java/io/servicecomb/provider/springmvc/reference/TestRestTemplateCopyHeaderFilter.java
@@ -55,6 +55,28 @@ public class TestRestTemplateCopyHeaderFilter {
   }
 
   @Test
+  public void beforeSendRequestWithNullHeader(@Mocked Invocation invocation) {
+    Map<String, Object> context = new HashMap<>(1);
+    HttpHeaders httpHeaders = new HttpHeaders();
+    context.put(RestConst.CONSUMER_HEADER, httpHeaders);
+    httpHeaders.add("headerName0", "headerValue0");
+    httpHeaders.add("headerName1", null);
+    httpHeaders.add("headerName2", "headerValue2");
+    new Expectations() {
+      {
+        invocation.getHandlerContext();
+        result = context;
+      }
+    };
+
+    HttpServletRequestEx requestEx = new CommonToHttpServletRequest(null, null, new HttpHeaders(), null, false);
+    filter.beforeSendRequest(invocation, requestEx);
+    Assert.assertEquals("headerValue0", requestEx.getHeader("headerName0"));
+    Assert.assertEquals("headerValue2", requestEx.getHeader("headerName2"));
+    Assert.assertNull(requestEx.getHeader("headerName1"));
+  }
+
+  @Test
   public void beforeSendRequestHaveHeader(@Mocked Invocation invocation) {
     HttpHeaders httpHeaders = new HttpHeaders();
     httpHeaders.add("name", "value");


### PR DESCRIPTION
see details in [https://servicecomb.atlassian.net/browse/JAV-560](https://servicecomb.atlassian.net/browse/JAV-560)

Check null arguments in invocation and do not copy them into requests to avoid NullPointerException in Netty.
My test demo is here: [https://github.com/yhs0092/javachassis-demo-header-transport](https://github.com/yhs0092/javachassis-demo-header-transport)
Null args in header can be held well now, no matter consumer use restTemplate or pojo client. 

But null args in path, query and body still may cause other problems. I don't know whether they are actually problem or it just a normal phenomenon.