### PR TITLE
[JAV-558] pullTask,use rev to ensure data consistency and reduce data…

### DIFF
--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/RegistryUtils.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/RegistryUtils.java
@@ -19,7 +19,6 @@ package io.servicecomb.serviceregistry;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.http.client.utils.URIBuilder;
@@ -37,6 +36,7 @@ import io.servicecomb.serviceregistry.api.registry.Microservice;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import io.servicecomb.serviceregistry.cache.InstanceCacheManager;
 import io.servicecomb.serviceregistry.client.ServiceRegistryClient;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstanceRefresh;
 import io.servicecomb.serviceregistry.config.ServiceRegistryConfig;
 import io.servicecomb.serviceregistry.definition.MicroserviceDefinition;
 import io.servicecomb.serviceregistry.registry.ServiceRegistryFactory;
@@ -193,9 +193,9 @@ public final class RegistryUtils {
     return new IpPort(publicAddressSetting, publishPort);
   }
 
-  public static List<MicroserviceInstance> findServiceInstance(String appId, String serviceName,
-      String versionRule) {
-    return serviceRegistry.findServiceInstance(appId, serviceName, versionRule);
+  public static MicroserviceInstanceRefresh findServiceInstance(String appId, String serviceName,
+      String versionRule, String revision) {
+    return serviceRegistry.findServiceInstance(appId, serviceName, versionRule, revision);
   }
 
   // update microservice instance properties

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/ServiceRegistry.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/ServiceRegistry.java
@@ -15,7 +15,6 @@
  */
 package io.servicecomb.serviceregistry;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -23,6 +22,7 @@ import io.servicecomb.serviceregistry.api.registry.Microservice;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import io.servicecomb.serviceregistry.cache.InstanceCacheManager;
 import io.servicecomb.serviceregistry.client.ServiceRegistryClient;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstanceRefresh;
 import io.servicecomb.serviceregistry.consumer.AppManager;
 
 public interface ServiceRegistry {
@@ -44,8 +44,8 @@ public interface ServiceRegistry {
 
   InstanceCacheManager getInstanceCacheManager();
 
-  List<MicroserviceInstance> findServiceInstance(String appId, String microserviceName,
-      String microserviceVersionRule);
+  MicroserviceInstanceRefresh findServiceInstance(String appId, String microserviceName,
+      String microserviceVersionRule, String revision);
 
   boolean updateMicroserviceProperties(Map<String, String> properties);
 

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/cache/InstanceCache.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/cache/InstanceCache.java
@@ -145,4 +145,5 @@ public class InstanceCache {
   public void setRevision(String revision) {
     this.revision = revision;
   }
+
 }

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/cache/InstanceCache.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/cache/InstanceCache.java
@@ -145,5 +145,4 @@ public class InstanceCache {
   public void setRevision(String revision) {
     this.revision = revision;
   }
-
 }

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/cache/InstanceCache.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/cache/InstanceCache.java
@@ -60,6 +60,9 @@ public class InstanceCache {
 
   private Object lockObj = new Object();
 
+  //cached Revision in the header
+  private String revision = "0";
+
   /**
    * 用于初始化场景
    */
@@ -134,4 +137,13 @@ public class InstanceCache {
   public String getAppId() {
     return appId;
   }
+
+  public String getRevision() {
+    return revision;
+  }
+
+  public void setRevision(String revision) {
+    this.revision = revision;
+  }
+
 }

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/cache/InstanceCacheManagerOld.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/cache/InstanceCacheManagerOld.java
@@ -33,7 +33,9 @@ import io.servicecomb.serviceregistry.ServiceRegistry;
 import io.servicecomb.serviceregistry.api.Const;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import io.servicecomb.serviceregistry.api.response.MicroserviceInstanceChangedEvent;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstanceRefresh;
 import io.servicecomb.serviceregistry.config.ServiceRegistryConfig;
+import io.servicecomb.serviceregistry.definition.DefinitionConst;
 import io.servicecomb.serviceregistry.task.InstancePullTask;
 import io.servicecomb.serviceregistry.task.event.ExceptionEvent;
 import io.servicecomb.serviceregistry.task.event.PeriodicPullEvent;
@@ -80,7 +82,9 @@ public class InstanceCacheManagerOld implements InstanceCacheManager {
   }
 
   private InstanceCache create(String appId, String microserviceName, String microserviceVersionRule) {
-    InstanceCache instCache = createInstanceCache(appId, microserviceName, microserviceVersionRule);
+    InstanceCache cache = new InstanceCache(appId, microserviceName, microserviceVersionRule, new HashMap<String, MicroserviceInstance>());
+    cache.setRevision(DefinitionConst.DEFAULT_REVISION);
+    InstanceCache instCache = createInstanceCache(cache);
     if (instCache == null) {
       return null;
     }
@@ -89,12 +93,24 @@ public class InstanceCacheManagerOld implements InstanceCacheManager {
     return instCache;
   }
 
-  public InstanceCache createInstanceCache(String appId, String microserviceName, String microserviceVersionRule) {
-    List<MicroserviceInstance> instances =
-        serviceRegistry.findServiceInstance(appId, microserviceName, microserviceVersionRule);
-    if (instances == null) {
+  public InstanceCache createInstanceCache(InstanceCache instanceCache) {
+    String appId = instanceCache.getAppId();
+    String microserviceName = instanceCache.getMicroserviceName();
+    String microserviceVersionRule = instanceCache.getMicroserviceVersionRule();
+    MicroserviceInstanceRefresh microerviceInstanceRefresh =
+        serviceRegistry.findServiceInstance(appId, microserviceName, microserviceVersionRule, instanceCache.getRevision());
+    if (microerviceInstanceRefresh == null) {
       return null;
     }
+    if (!microerviceInstanceRefresh.isNeedRefresh()) {
+      return instanceCache;
+    }
+    String revision = microerviceInstanceRefresh.getRevision();
+    String rev = instanceCache.getRevision();
+    if (Integer.valueOf(rev) - Integer.valueOf(revision) >= 0) {
+      return instanceCache;
+    }
+ List<MicroserviceInstance> instances = microerviceInstanceRefresh.getInstances();
 
     Map<String, MicroserviceInstance> instMap = new HashMap<>();
     for (MicroserviceInstance instance : instances) {
@@ -102,6 +118,7 @@ public class InstanceCacheManagerOld implements InstanceCacheManager {
     }
 
     InstanceCache instCache = new InstanceCache(appId, microserviceName, microserviceVersionRule, instMap);
+    instCache.setRevision(revision);
     return instCache;
   }
 
@@ -122,9 +139,11 @@ public class InstanceCacheManagerOld implements InstanceCacheManager {
   @Override
   public VersionedCache getOrCreateVersionedCache(String appId, String microserviceName,
       String microserviceVersionRule) {
+    InstanceCache instanceCache = new InstanceCache(appId, microserviceName, microserviceVersionRule, new HashMap<String, MicroserviceInstance>());
+    instanceCache.setRevision(DefinitionConst.DEFAULT_REVISION);
     String key = getKey(appId, microserviceName);
     InstanceCache cache = cacheMap.computeIfAbsent(key, k -> {
-      return createInstanceCache(appId, microserviceName, microserviceVersionRule);
+      return createInstanceCache(instanceCache);
     });
     return cache.getVersionedCache();
   }

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/client/LocalServiceRegistryClientImpl.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/client/LocalServiceRegistryClientImpl.java
@@ -39,6 +39,7 @@ import io.servicecomb.serviceregistry.api.registry.Microservice;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import io.servicecomb.serviceregistry.api.response.HeartbeatResponse;
 import io.servicecomb.serviceregistry.api.response.MicroserviceInstanceChangedEvent;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstanceRefresh;
 import io.servicecomb.serviceregistry.version.Version;
 import io.servicecomb.serviceregistry.version.VersionRule;
 import io.servicecomb.serviceregistry.version.VersionRuleUtils;
@@ -237,14 +238,17 @@ public class LocalServiceRegistryClientImpl implements ServiceRegistryClient {
   }
 
   @Override
-  public List<MicroserviceInstance> findServiceInstance(String selfMicroserviceId, String appId, String serviceName,
-      String strVersionRule) {
+  public MicroserviceInstanceRefresh findServiceInstance(String selfMicroserviceId, String appId, String serviceName,
+      String strVersionRule, String revision) {
     List<MicroserviceInstance> allInstances = new ArrayList<>();
+    MicroserviceInstanceRefresh microserviceInstanceRefresh = new MicroserviceInstanceRefresh();
 
     VersionRule versionRule = VersionRuleUtils.getOrCreate(strVersionRule);
     Microservice latestMicroservice = findLatest(appId, serviceName, versionRule);
     if (latestMicroservice == null) {
-      return allInstances;
+      microserviceInstanceRefresh.setInstances(allInstances);
+      microserviceInstanceRefresh.setRevision("0");
+      return microserviceInstanceRefresh;
     }
 
     Version latestVersion = VersionUtils.getOrCreate(latestMicroservice.getVersion());
@@ -262,8 +266,8 @@ public class LocalServiceRegistryClientImpl implements ServiceRegistryClient {
       Map<String, MicroserviceInstance> instances = microserviceInstanceMap.get(entry.getValue().getServiceId());
       allInstances.addAll(instances.values());
     }
-
-    return allInstances;
+    microserviceInstanceRefresh.setInstances(allInstances);
+    return microserviceInstanceRefresh;
   }
 
   @Override

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/client/ServiceRegistryClient.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/client/ServiceRegistryClient.java
@@ -24,6 +24,7 @@ import io.servicecomb.serviceregistry.api.registry.Microservice;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import io.servicecomb.serviceregistry.api.response.HeartbeatResponse;
 import io.servicecomb.serviceregistry.api.response.MicroserviceInstanceChangedEvent;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstanceRefresh;
 
 public interface ServiceRegistryClient {
   void init();
@@ -119,10 +120,10 @@ public interface ServiceRegistryClient {
 
   /**
    *
-   * 按照app+interface+version查询实例endpoints信息
+   * 按照app+interface+version+revision查询实例endpoints信息
    */
-  List<MicroserviceInstance> findServiceInstance(String consumerId, String appId, String serviceName,
-      String versionRule);
+  MicroserviceInstanceRefresh findServiceInstance(String consumerId, String appId, String serviceName,
+      String versionRule, String revision);
   
   /**
    * 通过serviceid， instanceid 获取instance对象。

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/MicroserviceInstanceRefresh.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/MicroserviceInstanceRefresh.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Huawei Technologies Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.servicecomb.serviceregistry.client.http;
+
+import java.util.List;
+
+import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+
+public class MicroserviceInstanceRefresh {
+  private boolean needRefresh = true;
+
+  private String revision;
+
+  private List<MicroserviceInstance> instances;
+
+  public boolean isNeedRefresh() {
+    return needRefresh;
+  }
+
+  public void setNeedRefresh(boolean needRefresh) {
+    this.needRefresh = needRefresh;
+  }
+
+  public String getRevision() {
+    return revision;
+  }
+
+  public void setRevision(String revision) {
+    this.revision = revision;
+  }
+
+  public List<MicroserviceInstance> getInstances() {
+    return instances;
+  }
+
+  public void setInstances(List<MicroserviceInstance> instances) {
+    this.instances = instances;
+  }
+
+}

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/consumer/MicroserviceVersions.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/consumer/MicroserviceVersions.java
@@ -32,6 +32,7 @@ import io.servicecomb.serviceregistry.RegistryUtils;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstanceStatus;
 import io.servicecomb.serviceregistry.api.response.MicroserviceInstanceChangedEvent;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstanceRefresh;
 import io.servicecomb.serviceregistry.definition.DefinitionConst;
 import io.servicecomb.serviceregistry.task.event.PullMicroserviceVersionsInstancesEvent;
 
@@ -45,6 +46,8 @@ public class MicroserviceVersions {
   private String microserviceName;
 
   private List<MicroserviceInstance> instances;
+
+  private String revision = "0";
 
   // key is service id
   private Map<String, MicroserviceVersion> versions = new ConcurrentHashMap<>();
@@ -89,6 +92,14 @@ public class MicroserviceVersions {
     return (T) versions.get(serviceId);
   }
 
+  public String getRevision() {
+    return revision;
+  }
+
+  public void setRevision(String revision) {
+    this.revision = revision;
+  }
+
   public void submitPull() {
     pendingPullCount.incrementAndGet();
     pullInstances();
@@ -99,17 +110,26 @@ public class MicroserviceVersions {
       return;
     }
 
-    List<MicroserviceInstance> pulledInstances = RegistryUtils.findServiceInstance(appId,
+    MicroserviceInstanceRefresh microserviceInstanceRefresh = RegistryUtils.findServiceInstance(appId,
         microserviceName,
-        DefinitionConst.VERSION_RULE_ALL);
-    if (pulledInstances == null) {
+        DefinitionConst.VERSION_RULE_ALL,
+        revision);
+    if (microserviceInstanceRefresh == null) {
       return;
     }
-
-    setInstances(pulledInstances);
+    boolean needRefresh = microserviceInstanceRefresh.isNeedRefresh();
+    if (!needRefresh) {
+      return;
+    }
+    String rev = microserviceInstanceRefresh.getRevision();
+    if (Integer.valueOf(revision) - Integer.valueOf(rev) >= 0) {
+      return;
+    }
+    List<MicroserviceInstance> pulledInstances = microserviceInstanceRefresh.getInstances();
+    setInstances(pulledInstances, rev);
   }
 
-  private void setInstances(List<MicroserviceInstance> pulledInstances) {
+  private void setInstances(List<MicroserviceInstance> pulledInstances, String rev) {
     synchronized (lock) {
       instances = pulledInstances
           .stream()
@@ -132,6 +152,7 @@ public class MicroserviceVersions {
       for (MicroserviceVersionRule microserviceVersionRule : versionRules.values()) {
         microserviceVersionRule.setInstances(instances);
       }
+      revision = rev;
     }
   }
 

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/definition/DefinitionConst.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/definition/DefinitionConst.java
@@ -30,6 +30,8 @@ public interface DefinitionConst {
 
   String DEFAULT_INSTANCE_ENVIRONMENT = "production";
 
+  String DEFAULT_REVISION = "0";
+
   String VERSION_RULE_LATEST = "latest";
 
   String VERSION_RULE_ALL = "0.0.0+";

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/registry/AbstractServiceRegistry.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/registry/AbstractServiceRegistry.java
@@ -37,6 +37,7 @@ import io.servicecomb.serviceregistry.cache.InstanceCacheManagerNew;
 import io.servicecomb.serviceregistry.cache.InstanceCacheManagerOld;
 import io.servicecomb.serviceregistry.client.IpPortManager;
 import io.servicecomb.serviceregistry.client.ServiceRegistryClient;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstanceRefresh;
 import io.servicecomb.serviceregistry.config.ServiceRegistryConfig;
 import io.servicecomb.serviceregistry.consumer.AppManager;
 import io.servicecomb.serviceregistry.consumer.MicroserviceVersionFactory;
@@ -207,17 +208,22 @@ public abstract class AbstractServiceRegistry implements ServiceRegistry {
     return true;
   }
 
-  public List<MicroserviceInstance> findServiceInstance(String appId, String serviceName,
-      String versionRule) {
-    List<MicroserviceInstance> instances = srClient.findServiceInstance(microservice.getServiceId(),
+  public MicroserviceInstanceRefresh findServiceInstance(String appId, String serviceName,
+      String versionRule, String revision) {
+    MicroserviceInstanceRefresh microserviceInstanceRefresh = srClient.findServiceInstance(microservice.getServiceId(),
         appId,
         serviceName,
-        versionRule);
-    if (instances == null) {
+        versionRule,
+        revision);
+    if (microserviceInstanceRefresh == null) {
       LOGGER.error("find empty instances from service center. service={}/{}/{}", appId, serviceName, versionRule);
       return null;
     }
-
+    if (!microserviceInstanceRefresh.isNeedRefresh()) {
+      LOGGER.info("Instances revision is not changed.");
+      return microserviceInstanceRefresh;
+    }
+    List<MicroserviceInstance> instances = microserviceInstanceRefresh.getInstances();
     LOGGER.info("find instances[{}] from service center success. service={}/{}/{}",
         instances.size(),
         appId,
@@ -229,7 +235,7 @@ public abstract class AbstractServiceRegistry implements ServiceRegistry {
           instance.getInstanceId(),
           instance.getEndpoints());
     }
-    return instances;
+    return microserviceInstanceRefresh;
   }
 
   @Override

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/task/InstancePullTask.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/task/InstancePullTask.java
@@ -38,9 +38,7 @@ public class InstancePullTask implements Runnable {
     try {
       serviceCenterTaskMonitor.beginCycle(interval);
       for (InstanceCache cache : this.cacheManager.getCachedEntries()) {
-        InstanceCache newCache = cacheManager.createInstanceCache(cache.getAppId(),
-            cache.getMicroserviceName(),
-            cache.getMicroserviceVersionRule());
+        InstanceCache newCache = cacheManager.createInstanceCache(cache);
         if (newCache != null) {
           cacheManager.updateInstanceMap(cache.getAppId(), cache.getMicroserviceName(), newCache);
         }

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/TestRegistry.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/TestRegistry.java
@@ -46,6 +46,7 @@ import io.servicecomb.config.ConfigUtil;
 import io.servicecomb.foundation.common.net.NetUtils;
 import io.servicecomb.serviceregistry.api.registry.Microservice;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstanceRefresh;
 import io.servicecomb.serviceregistry.registry.ServiceRegistryFactory;
 import mockit.Deencapsulation;
 import mockit.Expectations;
@@ -93,7 +94,8 @@ public class TestRegistry {
     Assert.assertEquals(serviceRegistry.getMicroservice(), microservice);
     Assert.assertEquals(serviceRegistry.getMicroserviceInstance(), RegistryUtils.getMicroserviceInstance());
 
-    List<MicroserviceInstance> instanceList = RegistryUtils.findServiceInstance("default", "default", "0.0.1");
+    MicroserviceInstanceRefresh microserviceInstanceRefresh = RegistryUtils.findServiceInstance("default", "default", "0.0.1", "0");
+    List<MicroserviceInstance> instanceList = microserviceInstanceRefresh.getInstances();
     Assert.assertEquals(1, instanceList.size());
     Assert.assertEquals(RegistryUtils.getMicroservice().getServiceId(), instanceList.get(0).getServiceId());
 

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/cache/TestInstanceCache.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/cache/TestInstanceCache.java
@@ -45,6 +45,7 @@ public class TestInstanceCache {
 
     instMap.put(instance.getInstanceId(), instance);
     instanceCache = new InstanceCache("testAppID", "testMicroServiceName", "1.0", instMap);
+    instanceCache.setRevision("1");
   }
 
   @Test
@@ -53,6 +54,7 @@ public class TestInstanceCache {
     Assert.assertEquals("testMicroServiceName", instanceCache.getMicroserviceName());
     Assert.assertEquals("1.0", instanceCache.getMicroserviceVersionRule());
     Assert.assertNotNull(instanceCache.getInstanceMap());
+    Assert.assertEquals("1", instanceCache.getRevision());
   }
 
   @Test

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/cache/TestInstanceCacheManagerOld.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/cache/TestInstanceCacheManagerOld.java
@@ -87,7 +87,7 @@ public class TestInstanceCacheManagerOld {
     oInstanceCacheManager.cacheMap.clear();
     new MockUp<InstanceCacheManagerOld>(oInstanceCacheManager) {
       @Mock
-      InstanceCache createInstanceCache(String appId, String microserviceName, String microserviceVersionRule) {
+      InstanceCache createInstanceCache(InstanceCache instanceCache) {
         return newServiceCache;
       }
     };

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/client/LocalServiceRegistryClientImplTest.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/client/LocalServiceRegistryClientImplTest.java
@@ -29,6 +29,7 @@ import org.junit.rules.ExpectedException;
 
 import io.servicecomb.serviceregistry.api.registry.Microservice;
 import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+import io.servicecomb.serviceregistry.client.http.MicroserviceInstanceRefresh;
 import io.servicecomb.serviceregistry.definition.DefinitionConst;
 
 public class LocalServiceRegistryClientImplTest {
@@ -52,8 +53,9 @@ public class LocalServiceRegistryClientImplTest {
   public void testLoadRegistryFile() {
     Assert.assertNotNull(registryClient);
     Assert.assertThat(registryClient.getAllMicroservices().size(), Is.is(1));
-    List<MicroserviceInstance> m =
-        registryClient.findServiceInstance("", "myapp", "springmvctest", DefinitionConst.VERSION_RULE_ALL);
+    MicroserviceInstanceRefresh microserviceInstanceRefresh =
+        registryClient.findServiceInstance("", "myapp", "springmvctest", DefinitionConst.VERSION_RULE_ALL, "0");
+    List<MicroserviceInstance> m = microserviceInstanceRefresh.getInstances();
     Assert.assertEquals(1, m.size());
   }
 
@@ -108,9 +110,9 @@ public class LocalServiceRegistryClientImplTest {
 
   @Test
   public void findServiceInstance_noInstances() {
-    List<MicroserviceInstance> result =
-        registryClient.findServiceInstance("self", appId, microserviceName, DefinitionConst.VERSION_RULE_ALL);
-
+    MicroserviceInstanceRefresh microserviceInstanceRefresh =
+        registryClient.findServiceInstance("self", appId, microserviceName, DefinitionConst.VERSION_RULE_ALL, "0");
+    List<MicroserviceInstance> result = microserviceInstanceRefresh.getInstances();
     Assert.assertThat(result, Matchers.empty());
   }
 
@@ -123,9 +125,9 @@ public class LocalServiceRegistryClientImplTest {
     instance.setServiceId(v1.getServiceId());
     registryClient.registerMicroserviceInstance(instance);
 
-    List<MicroserviceInstance> result =
-        registryClient.findServiceInstance("self", appId, microserviceName, "1.0.0");
-
+    MicroserviceInstanceRefresh microserviceInstanceRefresh =
+        registryClient.findServiceInstance("self", appId, microserviceName, "1.0.0", "0");
+    List<MicroserviceInstance> result = microserviceInstanceRefresh.getInstances();
     Assert.assertThat(result, Matchers.contains(instance));
   }
 

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/client/http/TestClienthttp.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/client/http/TestClienthttp.java
@@ -81,7 +81,8 @@ public class TestClienthttp {
         oClient.findServiceInstance(microservice.getServiceId(),
             microservice.getAppId(),
             microservice.getServiceName(),
-            microservice.getVersion()));
+            microservice.getVersion(),
+            "0"));
     Assert.assertEquals(null,
         oClient.getMicroserviceId(microservice.getAppId(),
             microservice.getServiceName(),

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/client/http/TestMicroserviceInstanceRefresh.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/client/http/TestMicroserviceInstanceRefresh.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Huawei Technologies Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.servicecomb.serviceregistry.client.http;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import io.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+
+public class TestMicroserviceInstanceRefresh {
+
+  MicroserviceInstanceRefresh microserviceInstanceRefresh = null;
+  List<MicroserviceInstance> instances = null;
+
+  @Before
+  public void setUp() throws Exception {
+    microserviceInstanceRefresh = new MicroserviceInstanceRefresh();
+    instances = new ArrayList<>();
+    instances.add(Mockito.mock(MicroserviceInstance.class));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    microserviceInstanceRefresh = null;
+    instances = null;
+  }
+
+  @Test
+  public void testDefaultValues() {
+    Assert.assertNull(microserviceInstanceRefresh.getRevision());
+    Assert.assertTrue(microserviceInstanceRefresh.isNeedRefresh());
+    Assert.assertNull(microserviceInstanceRefresh.getInstances());
+  }
+
+  @Test
+  public void testInitializedValues() {
+    initFields(); //Initialize the Object
+    Assert.assertEquals("1", microserviceInstanceRefresh.getRevision());
+    Assert.assertFalse(microserviceInstanceRefresh.isNeedRefresh());
+    Assert.assertEquals(1, microserviceInstanceRefresh.getInstances().size());
+  }
+
+  private void initFields() {
+    microserviceInstanceRefresh.setNeedRefresh(false);
+    microserviceInstanceRefresh.setRevision("1");
+    microserviceInstanceRefresh.setInstances(instances);
+  }
+}

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/client/http/TestServiceRegistryClientImpl.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/client/http/TestServiceRegistryClientImpl.java
@@ -123,7 +123,7 @@ public class TestServiceRegistryClientImpl {
         oClient.unregisterMicroserviceInstance("microserviceId", "microserviceInstanceId"));
     Assert.assertEquals(null, oClient.heartbeat("microserviceId", "microserviceInstanceId"));
     Assert.assertEquals(null,
-        oClient.findServiceInstance("selfMicroserviceId", "appId", "serviceName", "versionRule"));
+        oClient.findServiceInstance("selfMicroserviceId", "appId", "serviceName", "versionRule", "0"));
 
     Assert.assertEquals("a", new ClientException("a").getMessage());
   }

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/consumer/TestAppManager.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/consumer/TestAppManager.java
@@ -39,11 +39,13 @@ public class TestAppManager {
 
   String versionRule = "0+";
 
+  String revision = "0";
+
   @Test
   public void getOrCreateMicroserviceVersionRule() {
     new Expectations(RegistryUtils.class) {
       {
-        RegistryUtils.findServiceInstance(appId, serviceName, DefinitionConst.VERSION_RULE_ALL);
+        RegistryUtils.findServiceInstance(appId, serviceName, DefinitionConst.VERSION_RULE_ALL, revision);
         result = Collections.emptyList();
       }
     };
@@ -58,7 +60,7 @@ public class TestAppManager {
   public void getOrCreateMicroserviceVersions() {
     new Expectations(RegistryUtils.class) {
       {
-        RegistryUtils.findServiceInstance(appId, serviceName, DefinitionConst.VERSION_RULE_ALL);
+        RegistryUtils.findServiceInstance(appId, serviceName, DefinitionConst.VERSION_RULE_ALL, revision);
         result = Collections.emptyList();
       }
     };

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/consumer/TestMicroserviceManager.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/consumer/TestMicroserviceManager.java
@@ -42,6 +42,8 @@ public class TestMicroserviceManager {
 
   String versionRule = "0+";
 
+  String revision = "0";
+
   EventBus eventBus = new EventBus();
 
   AppManager appManager = new AppManager(eventBus);
@@ -52,7 +54,7 @@ public class TestMicroserviceManager {
   public void getOrCreateMicroserviceVersionRule() {
     new Expectations(RegistryUtils.class) {
       {
-        RegistryUtils.findServiceInstance(appId, serviceName, DefinitionConst.VERSION_RULE_ALL);
+        RegistryUtils.findServiceInstance(appId, serviceName, DefinitionConst.VERSION_RULE_ALL, revision);
         result = Collections.emptyList();
       }
     };

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/task/TestInstancePullTask.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/task/TestInstancePullTask.java
@@ -42,9 +42,9 @@ public class TestInstancePullTask {
       {
         cacheManager.getCachedEntries();
         result = caches;
-        cacheManager.createInstanceCache("sc", "sc", "0.0.1");
+        cacheManager.createInstanceCache(serviceCenter);
         result = changedServiceCenter;
-        cacheManager.createInstanceCache("other", "other", "0.0.1");
+        cacheManager.createInstanceCache(otherService);
         result = changedService;
         cacheManager.updateInstanceMap("sc", "sc", changedServiceCenter);
         cacheManager.updateInstanceMap("other", "other", changedService);
@@ -68,9 +68,9 @@ public class TestInstancePullTask {
       {
         cacheManager.getCachedEntries();
         result = caches;
-        cacheManager.createInstanceCache("sc", "sc", "0.0.1");
+        cacheManager.createInstanceCache(serviceCenter);
         result = serviceCenter;
-        cacheManager.createInstanceCache("other", "other", "0.0.1");
+        cacheManager.createInstanceCache(otherService);
         result = otherService;
       }
     };
@@ -93,7 +93,7 @@ public class TestInstancePullTask {
       {
         cacheManager.getCachedEntries();
         result = caches;
-        cacheManager.createInstanceCache("sc", "sc", "0.0.1");
+        cacheManager.createInstanceCache(serviceCenter);
         result = new java.lang.Error();
       }
     };


### PR DESCRIPTION
Not only InstanceCacheManagerOld, but also InstanceCacheManagerNew was modified.
When pull task,SC will return to the result with the version number X-Resource-Revision in the HEADER，SDK recodes this rev and sends it to SC at the next request.
If the rev of SDK is greater than the rev of SC, it means that the result of SDK is new to SC, SC doesn't need to be processed, and returns 304 to indicate that SDK's cache is not refreshed.
If the rev of SDK is less than SC's rev, SC returns the updated result set to SDK, SDK refreshes the cache and
updates the Rev.
The effect is that SDK requests different SC and does not have data inconsistencies, at the same time reducing the amount of data transmission in the channel
