### PR TITLE
[JAV-560] fix null header process logic on consumer side

### DIFF
--- a/common/common-rest/src/main/java/io/servicecomb/common/rest/codec/param/HeaderProcessorCreator.java
+++ b/common/common-rest/src/main/java/io/servicecomb/common/rest/codec/param/HeaderProcessorCreator.java
@@ -56,6 +56,10 @@ public class HeaderProcessorCreator implements ParamValueProcessorCreator {
 
     @Override
     public void setValue(RestClientRequest clientRequest, Object arg) throws Exception {
+      if (null == arg) {
+        // null header should not be set to clientRequest to avoid NullPointerException in Netty.
+        return;
+      }
       clientRequest.putHeader(paramPath, RestObjectMapper.INSTANCE.convertToString(arg));
     }
 

--- a/common/common-rest/src/main/java/io/servicecomb/common/rest/codec/param/HeaderProcessorCreator.java
+++ b/common/common-rest/src/main/java/io/servicecomb/common/rest/codec/param/HeaderProcessorCreator.java
@@ -22,6 +22,9 @@ import java.util.Enumeration;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
@@ -30,6 +33,8 @@ import io.servicecomb.common.rest.codec.RestObjectMapper;
 import io.swagger.models.parameters.Parameter;
 
 public class HeaderProcessorCreator implements ParamValueProcessorCreator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HeaderProcessorCreator.class);
+
   public static final String PARAMTYPE = "header";
 
   public static class HeaderProcessor extends AbstractParamProcessor {
@@ -58,6 +63,7 @@ public class HeaderProcessorCreator implements ParamValueProcessorCreator {
     public void setValue(RestClientRequest clientRequest, Object arg) throws Exception {
       if (null == arg) {
         // null header should not be set to clientRequest to avoid NullPointerException in Netty.
+        LOGGER.debug("Header arg is null, will not be set into clientRequest. paramPath = [{}]", paramPath);
         return;
       }
       clientRequest.putHeader(paramPath, RestObjectMapper.INSTANCE.convertToString(arg));

--- a/common/common-rest/src/test/java/io/servicecomb/common/rest/codec/param/TestHeaderProcessor.java
+++ b/common/common-rest/src/test/java/io/servicecomb/common/rest/codec/param/TestHeaderProcessor.java
@@ -162,6 +162,14 @@ public class TestHeaderProcessor {
   }
 
   @Test
+  public void testSetValueNull() throws Exception {
+    createClientRequest();
+    HeaderProcessor processor = createProcessor("h1", String.class);
+    processor.setValue(clientRequest, null);
+    Assert.assertEquals(0, headers.size());
+  }
+
+  @Test
   public void testSetValueDate() throws Exception {
     Date date = new Date();
     String strDate = ISO8601Utils.format(date);

--- a/providers/provider-springmvc/src/main/java/io/servicecomb/provider/springmvc/reference/RestTemplateCopyHeaderFilter.java
+++ b/providers/provider-springmvc/src/main/java/io/servicecomb/provider/springmvc/reference/RestTemplateCopyHeaderFilter.java
@@ -16,6 +16,8 @@
 
 package io.servicecomb.provider.springmvc.reference;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 
 import io.servicecomb.common.rest.RestConst;
@@ -26,6 +28,8 @@ import io.servicecomb.foundation.vertx.http.HttpServletResponseEx;
 import io.servicecomb.swagger.invocation.Response;
 
 public class RestTemplateCopyHeaderFilter implements HttpClientFilter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RestTemplateCopyHeaderFilter.class);
+
   @Override
   public int getOrder() {
     return Integer.MIN_VALUE;
@@ -42,6 +46,7 @@ public class RestTemplateCopyHeaderFilter implements HttpClientFilter {
       for (String value : values) {
         // null args should not be set to requestEx to avoid NullPointerException in Netty.
         if (null == value) {
+          LOGGER.debug("header value is null, key = [{}]. Will not set this header into request", key);
           continue;
         }
         requestEx.addHeader(key, value);

--- a/providers/provider-springmvc/src/main/java/io/servicecomb/provider/springmvc/reference/RestTemplateCopyHeaderFilter.java
+++ b/providers/provider-springmvc/src/main/java/io/servicecomb/provider/springmvc/reference/RestTemplateCopyHeaderFilter.java
@@ -40,6 +40,10 @@ public class RestTemplateCopyHeaderFilter implements HttpClientFilter {
 
     httpHeaders.forEach((key, values) -> {
       for (String value : values) {
+        // null args should not be set to requestEx to avoid NullPointerException in Netty.
+        if (null == value) {
+          continue;
+        }
         requestEx.addHeader(key, value);
       }
     });

--- a/providers/provider-springmvc/src/test/java/io/servicecomb/provider/springmvc/reference/TestRestTemplateCopyHeaderFilter.java
+++ b/providers/provider-springmvc/src/test/java/io/servicecomb/provider/springmvc/reference/TestRestTemplateCopyHeaderFilter.java
@@ -55,6 +55,28 @@ public class TestRestTemplateCopyHeaderFilter {
   }
 
   @Test
+  public void beforeSendRequestWithNullHeader(@Mocked Invocation invocation) {
+    Map<String, Object> context = new HashMap<>(1);
+    HttpHeaders httpHeaders = new HttpHeaders();
+    context.put(RestConst.CONSUMER_HEADER, httpHeaders);
+    httpHeaders.add("headerName0", "headerValue0");
+    httpHeaders.add("headerName1", null);
+    httpHeaders.add("headerName2", "headerValue2");
+    new Expectations() {
+      {
+        invocation.getHandlerContext();
+        result = context;
+      }
+    };
+
+    HttpServletRequestEx requestEx = new CommonToHttpServletRequest(null, null, new HttpHeaders(), null, false);
+    filter.beforeSendRequest(invocation, requestEx);
+    Assert.assertEquals("headerValue0", requestEx.getHeader("headerName0"));
+    Assert.assertEquals("headerValue2", requestEx.getHeader("headerName2"));
+    Assert.assertNull(requestEx.getHeader("headerName1"));
+  }
+
+  @Test
   public void beforeSendRequestHaveHeader(@Mocked Invocation invocation) {
     HttpHeaders httpHeaders = new HttpHeaders();
     httpHeaders.add("name", "value");


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://https://servicecomb.atlassian.net/projects/JAV/issues) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[JAV-XXX] Fixes bug in ApproximateQuantiles`, where you replace `JAV-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

see details in [https://servicecomb.atlassian.net/browse/JAV-560]

Check null arguments in invocation and do not copy them into requests to avoid NullPointerException in Netty.
My test demo is here: [https://github.com/yhs0092/javachassis-demo-header-transport]