### PR TITLE
[JAV_567] Change the timeout of heartbeat for one second

### DIFF
--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/config/ServiceRegistryConfig.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/config/ServiceRegistryConfig.java
@@ -43,7 +43,7 @@ public final class ServiceRegistryConfig {
 
   private static final int PROTOCOL_HTTP_PORT = 80;
 
-  private static final int DEFAULT_TIMEOUT_IN_MS = 30000;
+  private static final int DEFAULT_TIMEOUT_IN_MS = 1000;
 
   private static final int DEFAULT_TIMEOUT_IN_SECONDS = 30;
 

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/config/TestServiceRegistryConfig.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/config/TestServiceRegistryConfig.java
@@ -41,7 +41,7 @@ public class TestServiceRegistryConfig {
   public void testServiceRegistryConfig() {
     ServiceRegistryConfig oConfig = ServiceRegistryConfig.INSTANCE;
     Assert.assertEquals(null, oConfig.getAccessKey());
-    Assert.assertEquals(30000, oConfig.getConnectionTimeout());
+    Assert.assertEquals(1000, oConfig.getConnectionTimeout());
     Assert.assertNotEquals(null, oConfig.getHeartbeatInterval());
     Assert.assertEquals("HTTP_1_1", oConfig.getHttpVersion().name());
     Assert.assertEquals("rest", oConfig.getTransport());


### PR DESCRIPTION
场景：挂起一个服务中心实例，心跳超时。在域名的情况下，下次心跳还可能访问到该实例，从而导致心跳过期，实例被移除。
需要优化的措施：改小httpclient超时时间，比如1s，和其他请求使用不一样的超时时间。
