### PR TITLE
[JAV_567] Change the timeout of heartbeat for one second

### DIFF
--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/RestUtils.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/RestUtils.java
@@ -79,7 +79,11 @@ final class RestUtils {
             responseHandler.handle(new RestResponse(requestContext, response));
           });
 
-      httpClientRequest.setTimeout(ServiceRegistryConfig.INSTANCE.getRequestTimeout())
+      int timeout = ServiceRegistryConfig.INSTANCE.getRequestTimeout();
+      if (requestContext.getUri().endsWith("/heartbeat")) {
+        timeout = 1;
+      }
+      httpClientRequest.setTimeout(timeout)
           .exceptionHandler(e -> {
             LOGGER.error("{} {} fail, endpoint is {}:{}, message: {}",
                 httpMethod,


### PR DESCRIPTION
场景：挂起一个服务中心实例，心跳超时。在域名的情况下，下次心跳还可能访问到该实例，从而导致心跳过期，实例被移除。
需要优化的措施：改小httpclient超时时间，比如1s，和其他请求使用不一样的超时时间。
