### PR TITLE
[JAV-567] Change the timeout of heartbeat request

### DIFF
--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/RequestParam.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/RequestParam.java
@@ -41,6 +41,8 @@ public class RequestParam {
 
   private Map<String, String> cookies;
 
+  private long timeout;
+
   public Map<String, String> getCookies() {
     return cookies;
   }
@@ -129,4 +131,14 @@ public class RequestParam {
     headers.put(key, value);
     return this;
   }
+
+  public long getTimeout() {
+    return timeout;
+  }
+
+  public RequestParam setTimeout(long timeout) {
+    this.timeout = timeout;
+    return this;
+  }
+
 }

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/RestUtils.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/RestUtils.java
@@ -54,6 +54,14 @@ final class RestUtils {
   }
 
   public static void httpDo(RequestContext requestContext, Handler<RestResponse> responseHandler) {
+    if (requestContext.getParams().getTimeout() != 0) {
+      httpDo(requestContext.getParams().getTimeout(), requestContext, responseHandler);
+      return;
+    }
+    httpDo(ServiceRegistryConfig.INSTANCE.getRequestTimeout(), requestContext, responseHandler);
+  }
+  
+  public static void httpDo(long timeout, RequestContext requestContext, Handler<RestResponse> responseHandler) {
     HttpClientWithContext vertxHttpClient = HttpClientPool.INSTANCE.getClient();
     vertxHttpClient.runOnContext(httpClient -> {
       IpPort ipPort = requestContext.getIpPort();
@@ -79,7 +87,7 @@ final class RestUtils {
             responseHandler.handle(new RestResponse(requestContext, response));
           });
 
-      httpClientRequest.setTimeout(ServiceRegistryConfig.INSTANCE.getRequestTimeout())
+      httpClientRequest.setTimeout(timeout)
           .exceptionHandler(e -> {
             LOGGER.error("{} {} fail, endpoint is {}:{}, message: {}",
                 httpMethod,

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/ServiceRegistryClientImpl.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/client/http/ServiceRegistryClientImpl.java
@@ -55,6 +55,7 @@ import io.servicecomb.serviceregistry.api.response.RegisterInstanceResponse;
 import io.servicecomb.serviceregistry.client.ClientException;
 import io.servicecomb.serviceregistry.client.IpPortManager;
 import io.servicecomb.serviceregistry.client.ServiceRegistryClient;
+import io.servicecomb.serviceregistry.config.ServiceRegistryConfig;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientResponse;
@@ -429,7 +430,7 @@ public final class ServiceRegistryClientImpl implements ServiceRegistryClient {
     CountDownLatch countDownLatch = new CountDownLatch(1);
     RestUtils.put(ipPort,
         String.format(Const.REGISTRY_API.MICROSERVICE_HEARTBEAT, microserviceId, microserviceInstanceId),
-        new RequestParam(),
+        new RequestParam().setTimeout(ServiceRegistryConfig.INSTANCE.getHeartBeatRequestTimeout()),
         syncHandler(countDownLatch, HttpClientResponse.class, holder));
 
     try {

--- a/service-registry/src/main/java/io/servicecomb/serviceregistry/config/ServiceRegistryConfig.java
+++ b/service-registry/src/main/java/io/servicecomb/serviceregistry/config/ServiceRegistryConfig.java
@@ -49,6 +49,8 @@ public final class ServiceRegistryConfig {
 
   private static final int DEFAULT_REQUEST_TIMEOUT_IN_MS = 30000;
 
+  private static final int DEFAULT_REQUEST_HEARTBEAT_TIMEOUT_IN_MS = 3000;
+
   private static final int DEFAULT_CHECK_INTERVAL_IN_S = 30;
 
   private static final int DEFAULT_CHECK_TIMES = 3;
@@ -177,6 +179,15 @@ public final class ServiceRegistryConfig {
             .getIntProperty("cse.service.registry.client.timeout.request", DEFAULT_REQUEST_TIMEOUT_IN_MS);
     int timeout = property.get();
     return timeout < 1 ? DEFAULT_REQUEST_TIMEOUT_IN_MS : timeout;
+  }
+
+  //Set the timeout of the heartbeat request
+  public int getHeartBeatRequestTimeout() {
+    DynamicIntProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getIntProperty("cse.service.registry.client.timeout.heartbeat", DEFAULT_REQUEST_HEARTBEAT_TIMEOUT_IN_MS);
+    int timeout = property.get();
+    return timeout < 1 ? DEFAULT_REQUEST_HEARTBEAT_TIMEOUT_IN_MS : timeout;
   }
 
   public int getHeartbeatInterval() {

--- a/service-registry/src/test/java/io/servicecomb/serviceregistry/config/TestServiceRegistryConfig.java
+++ b/service-registry/src/test/java/io/servicecomb/serviceregistry/config/TestServiceRegistryConfig.java
@@ -49,6 +49,7 @@ public class TestServiceRegistryConfig {
     Assert.assertEquals(1, oConfig.getWorkerPoolSize());
     Assert.assertEquals(true, oConfig.isSsl());
     Assert.assertEquals(30000, oConfig.getRequestTimeout());
+    Assert.assertEquals(3000, oConfig.getHeartBeatRequestTimeout());
     Assert.assertNotEquals(null, oConfig.getResendHeartBeatTimes());
     Assert.assertEquals(false, oConfig.isPreferIpAddress());
     Assert.assertEquals(true, oConfig.isWatch());


### PR DESCRIPTION
场景：挂起一个服务中心实例，心跳超时。在域名的情况下，下次心跳还可能访问到该实例，从而导致心跳过期，实例被移除。
需要优化的措施：心跳单独设置超时时间，比如3s，和其他请求使用不一样的超时时间。